### PR TITLE
Added text extraction from byte arrays

### DIFF
--- a/src/TikaOnDotNet.Tests/text_extraction.cs
+++ b/src/TikaOnDotNet.Tests/text_extraction.cs
@@ -111,5 +111,14 @@ namespace TikaOnDotNet.Tests
 
 			textExtractionResult.Text.ShouldContain("Use the force duke");
 		}
+		
+		[Test]
+		public void should_extract_from_xls_with_byte()
+		{
+			var data = System.IO.File.ReadAllBytes("files/Tika.xls");
+			var textExtractionResult = _cut.Extract(data);
+
+			textExtractionResult.Text.ShouldContain("Use the force duke");
+		}
 	}
 }

--- a/src/TikaOnDotnet/TextExtractor.cs
+++ b/src/TikaOnDotnet/TextExtractor.cs
@@ -63,6 +63,30 @@ namespace TikaOnDotNet
 				throw new ApplicationException("Extraction of text from the file '{0}' failed.".ToFormat(filePath), ex);
 			}
 		}
+		
+		public TextExtractionResult Extract(byte[] data)
+        {
+            var parser = new AutoDetectParser();
+            var metadata = new Metadata();
+            var parseContext = new ParseContext();
+            Class parserClass = parser.GetType();
+            parseContext.set(parserClass, parser);
+
+            try
+            {
+                using (InputStream inputStream = TikaInputStream.get(data, metadata))
+                {
+                    parser.parse(inputStream, getTransformerHandler(), metadata, parseContext);
+                    inputStream.close();
+                }
+
+                return assembleExtractionResult(_outputWriter.ToString(), metadata);
+            }
+            catch (Exception ex)
+            {
+                throw new ApplicationException("Extraction of text from the byte array failed.", ex);
+            }
+        }
 
 		private static TextExtractionResult assembleExtractionResult(string text, Metadata metadata)
 		{


### PR DESCRIPTION
Added a overload to the TextExtractor.Extract method that takes a byte
array instead of a file. Also added a test for it in the TikaOnDotNet.Tests project. 
