### PR TITLE
Update Tika to version 1.7

### DIFF
--- a/ripple.config
+++ b/ripple.config
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ripple xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<ripple xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>tikaondotnet</Name>
   <NugetSpecFolder>packaging/nuget</NugetSpecFolder>
   <SourceFolder>src</SourceFolder>
@@ -22,8 +22,5 @@
     <Dependency Name="structuremap.automocking" Version="2.6.3" Mode="Fixed" />
   </Nugets>
   <Groups />
-  <References>
-    <IgnoreAssemblies />
-  </References>
   <Nuspecs />
 </ripple>

--- a/src/TikaOnDotNet.Tests/TikaOnDotNet.Tests.csproj
+++ b/src/TikaOnDotNet.Tests/TikaOnDotNet.Tests.csproj
@@ -122,7 +122,7 @@
       <HintPath>..\packages\NUnit\lib\pnunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Rhino.Mocks">
-      <HintPath>..\packages\RhinoMocks\lib\net40\Rhino.Mocks.dll</HintPath>
+      <HintPath>..\packages\RhinoMocks\lib\net\Rhino.Mocks.dll</HintPath>
     </Reference>
     <Reference Include="StructureMap">
       <HintPath>..\packages\structuremap\lib\StructureMap.dll</HintPath>


### PR DESCRIPTION
#20 - Updated Tika to version 1.7. 

I did not update IKVM though. So, the tika-app.dll was compiled with the 7.4.5196.0 version of the IKVM tools.

Also, when building via prior to making any changes two files were automatically modified so I commit those changes as well. It seems like the right thing to do in this case.