### PR TITLE
Fix Dependencies to have minimum versions

### DIFF
--- a/Release-Notes.md
+++ b/Release-Notes.md
@@ -1,3 +1,7 @@
+## 1.12.1
+
+Fix TikaOnDotNet.TextExtractor to depend on a compatible version (1.12) of TikaOnDotNet.
+
 ## 1.12.0
 
 **Breaking Change**: This release splits **TikaOneDotNet** into two Nugets.

--- a/src/TikaOnDotnet.TextExtractor/paket.template
+++ b/src/TikaOnDotnet.TextExtractor/paket.template
@@ -6,6 +6,6 @@ description
 files
     bin\Release\TikaOnDotNet.* ==> lib
 dependencies
-    TikaOnDotnet
+    TikaOnDotnet ~> 1.12
 projectUrl
   https://github.com/KevM/tikaondotnet

--- a/src/TikaOnDotnet/paket.template
+++ b/src/TikaOnDotnet/paket.template
@@ -6,4 +6,4 @@ description
 files
     ..\..\lib\tika-app.dll ==> lib
 dependencies
-      IKVM
+      IKVM 8.1.5717


### PR DESCRIPTION
- TikaOnDotNet needs to have at minimum IKVM 8.1.5717
- TikeOnDotNet.TextExtractor needs at least TikaOnDotNet 1.12

Fixes #41 