### PR TITLE
Fix text extractor version dep

### DIFF
--- a/Release-Notes.md
+++ b/Release-Notes.md
@@ -1,3 +1,7 @@
+## 1.13.1
+
+- Update TextExtractor dependency metadata to properly sync with TikaOnDotNet
+
 ## 1.13
 
 - Updated Tika dependency to 1.13.

--- a/src/TikaOnDotnet.TextExtractor/paket.template
+++ b/src/TikaOnDotnet.TextExtractor/paket.template
@@ -6,6 +6,6 @@ description
 files
     bin\Release\TikaOnDotNet.* ==> lib
 dependencies
-    TikaOnDotnet ~> 1.12.2
+    TikaOnDotnet
 projectUrl
   https://github.com/KevM/tikaondotnet


### PR DESCRIPTION
A couple of people reported that the version of `TextExtractor` was not lined up with `TikaOnDotNet`. This PR should fix that.